### PR TITLE
feat: bump action to use node20 runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
     description: 'Available platforms (comma separated)'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
**Description:**

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20) (https://github.com/actions/runner/pull/2732).

-----------------
A major version bump might be needed after the PRs merge.