### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       -
         name: Stop docker
         run: |
-          sudo systemctl stop docker
+          sudo systemctl stop docker docker.socket
       -
         name: Set up QEMU
         id: qemu


### PR DESCRIPTION
related to https://github.com/docker/setup-qemu-action/actions/runs/6071960068/job/16471041486#step:5:22

![image](https://github.com/docker/setup-qemu-action/assets/1951866/751f15b2-3882-4a48-b633-17f587844f64)

docker-ce packages are now installed on GitHub Runners. Same as https://github.com/docker/setup-buildx-action/commit/93b8ecaa2c1900a3605b90629b56d2208bf1d41f