### PR TITLE
Provide usage examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64, i386
+      -
+        name: Create an example binary for AArch64
+        run: |
+          go mod init hello
+          cat << EOL > hello.go
+          package main
+
+          func main() {
+            println("Hello, AArch64!")
+          }
+          EOL
+          GOARCH=arm64 go build hello.go
+      -
+        name: This would fail without docker/setup-qemu-action
+        run: ./hello
+      -
+        name: You can also run images from other platforms
+        run: docker run --platform linux/i386 hello-world
 ```
 
 > [!NOTE]


### PR DESCRIPTION
We provide two simple examples of invoking `qemu-{arch}-static` (or more precisely, we let the kernel do the invocation.)

Closes: #95