### PR TITLE
dependabot: skip for update-dist commits

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -50,7 +50,7 @@ jobs:
               git config user.name "github-actions[bot]"
               git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
               git add dist
-              git commit -m "chore: update generated content"
+              git commit -m "[dependabot skip] chore: update generated content"
               git push
             )
           else


### PR DESCRIPTION
This updates the `update-dist` workflow so generated dist commits include `[dependabot skip]` in the commit message.

Dependabot treats extra commits on its PRs specially, and GitHub documents `[dependabot skip]` as the supported marker for allowing Dependabot to rebase and force-push over those commits. The relevant documentation is https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/manage-dependabot-prs?learn=dependabot_alerts#allowing-dependabot-to-rebase-and-force-push-over-extra-commits.

This will avoid this kind of blockers during rebase: https://github.com/docker/setup-qemu-action/pull/251#issuecomment-4060150406