### PR TITLE
chore: allow actions-toolkit to bypass yarn age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,9 @@ logFilters:
   - code: YN0086
     level: discard
 
+npmPreapprovedPackages:
+  - "@docker/actions-toolkit"
+
 compressionLevel: mixed
 enableGlobalCache: false
 enableHardenedMode: true


### PR DESCRIPTION
relates to https://github.com/docker/setup-qemu-action/actions/runs/28505028156/job/84491274379#step:3:993

This change lets `@docker/actions-toolkit` bypass Yarn's `npmMinimalAgeGate` while keeping the two-day age gate for all other npm packages.

The Yarn config now lists `@docker/actions-toolkit` under `npmPreapprovedPackages`, which tells Yarn to exempt that package from the minimum release age check: https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages

Dependabot already excludes this internal package from its cooldown, but Yarn still quarantined fresh releases during resolution. Preapproving only this package keeps the broader supply-chain delay intact without blocking internal toolkit updates.